### PR TITLE
New functions to control the console standard output generated by ApproveLastRequest

### DIFF
--- a/TunableSSLValidator.psm1
+++ b/TunableSSLValidator.psm1
@@ -176,10 +176,9 @@ function Enable-ShowConsoleStandardOutput {
 }
 function Get-ShowConsoleStandardOutput {
     #.Synopsis
-    #  Retrieve the setting for whether methods to write to the standard output stream
+    #  Retrieves the setting for whether methods to write to the standard output stream
     [Huddled.Net.TunableValidator]::ShowConsoleStandardOutput
 }
-
 
 
 function Disable-SSLChainValidation {
@@ -192,6 +191,13 @@ function Enable-SSLChainValidation {
     #  Enables normal validation of the SSL certificate chain
     [Huddled.Net.TunableValidator]::IgnoreChainErrors = $False
 }
+
+function Get-IgnoreChainErrors {
+    #.Synopsis
+    #  Retrieves validation setting for the SSL certificate chain
+    [Huddled.Net.TunableValidator]::IgnoreChainErrors
+}
+
 
 function Invoke-WebRequest {
     [CmdletBinding(HelpUri='http://go.microsoft.com/fwlink/?LinkID=217035')]

--- a/TunableSSLValidator.psm1
+++ b/TunableSSLValidator.psm1
@@ -164,6 +164,24 @@ function Remove-SessionTrustedCertificate {
     }
 }
 
+function Disable-ShowConsoleStandardOutput {
+    #.Synopsis
+    #  Disables methods from writing to the standard output stream
+    [Huddled.Net.TunableValidator]::ShowConsoleStandardOutput = $False
+}
+function Enable-ShowConsoleStandardOutput {
+    #.Synopsis
+    #  Enables methods to write to the standard output stream
+    [Huddled.Net.TunableValidator]::ShowConsoleStandardOutput = $True
+}
+function Get-ShowConsoleStandardOutput {
+    #.Synopsis
+    #  Retrieve the setting for whether methods to write to the standard output stream
+    [Huddled.Net.TunableValidator]::ShowConsoleStandardOutput
+}
+
+
+
 function Disable-SSLChainValidation {
     #.Synopsis
     #  Disables validation of the SSL certificate chain, essentially allowing self-signed certificates
@@ -501,5 +519,5 @@ function Export-ODataEndpointProxy {
 
 }
 
-# Whould add a module unload hook to remove the validation hook
+# Should add a module unload hook to remove the validation hook
 # [Net.ServicePointManager]::ServerCertificateValidationCallback = $null

--- a/TunableValidator.cs
+++ b/TunableValidator.cs
@@ -22,7 +22,7 @@ namespace Huddled.Net
       {
           if (ShowConsoleStandardOutput)
           {
-              Console.Out.Write("{1:yyy-MM-dd HH:mm:ss} {0}", msg, DateTime.Now, Environment.NewLine);
+              Console.Out.Write("{1:yyy-MM-dd HH:mm:ss} {0}{2}", msg, DateTime.Now, Environment.NewLine);
           }
       }
 
@@ -65,7 +65,6 @@ namespace Huddled.Net
       {
          bool result = true;
          var request = sender as WebRequest;
-
 
          // If there's no remote certificate, we're always going to fail (why are we even in here?)
          if (SslPolicyErrors.RemoteCertificateNotAvailable ==

--- a/TunableValidator.cs
+++ b/TunableValidator.cs
@@ -10,15 +10,26 @@ namespace Huddled.Net
    public class TunableValidator
    {
       public static bool IgnoreChainErrors { get; set; }
+      public static bool ShowConsoleStandardOutput { get; set; } 
       private static readonly Dictionary<string, string> Trusted = new Dictionary<string, string>();
       private static bool _allowNextCert;
       private static bool _addNextCert;
       private static string _lasthash;
       private static string _lasthost;
 
-      public static void SetValidator(bool ignoreChainErrors = false, Hashtable trustedCerts = null)
+
+      public static void WriteOutToConsole(string msg)
+      {
+          if (ShowConsoleStandardOutput)
+          {
+              Console.Out.Write("{1:yyy-MM-dd HH:mm:ss} {0}", msg, DateTime.Now);
+          }
+      }
+
+      public static void SetValidator(bool ignoreChainErrors = false, bool showConsoleStandardOutput = true, Hashtable trustedCerts = null)
       {
          IgnoreChainErrors = ignoreChainErrors;
+         ShowConsoleStandardOutput = showConsoleStandardOutput;
 
          if (trustedCerts != null)
          {
@@ -33,7 +44,8 @@ namespace Huddled.Net
       public static void ApproveLastRequest()
       {
          Trusted.Add(_lasthash, _lasthost);
-         Console.WriteLine(string.Format("Added \"{0}\"=\"{1}\"", _lasthash, _lasthost));
+         //         Console.WriteLine(string.Format("Added \"{0}\"=\"{1}\"", _lasthash, _lasthost));
+         WriteOutToConsole("Added \"" + _lasthash + "\"=\"" + _lasthost + "\"");
       }
 
       public static void ApproveNextRequest(bool andTrustCert = false)

--- a/TunableValidator.cs
+++ b/TunableValidator.cs
@@ -10,7 +10,7 @@ namespace Huddled.Net
    public class TunableValidator
    {
       public static bool IgnoreChainErrors { get; set; }
-      public static bool ShowConsoleStandardOutput { get; set; } 
+      public static bool ShowConsoleStandardOutput { get; set; }
       private static readonly Dictionary<string, string> Trusted = new Dictionary<string, string>();
       private static bool _allowNextCert;
       private static bool _addNextCert;
@@ -22,7 +22,7 @@ namespace Huddled.Net
       {
           if (ShowConsoleStandardOutput)
           {
-              Console.Out.Write("{1:yyy-MM-dd HH:mm:ss} {0}", msg, DateTime.Now);
+              Console.Out.Write("{1:yyy-MM-dd HH:mm:ss} {0}", msg, DateTime.Now, Environment.NewLine);
           }
       }
 

--- a/TunableValidator.cs
+++ b/TunableValidator.cs
@@ -26,7 +26,7 @@ namespace Huddled.Net
           }
       }
 
-      public static void SetValidator(bool ignoreChainErrors = false, bool showConsoleStandardOutput = true, Hashtable trustedCerts = null)
+      public static void SetValidator(bool ignoreChainErrors = false, Hashtable trustedCerts = null, bool showConsoleStandardOutput = true)
       {
          IgnoreChainErrors = ignoreChainErrors;
          ShowConsoleStandardOutput = showConsoleStandardOutput;


### PR DESCRIPTION
I added a public boolean ShowConsoleStandardOutput which controls whether the ApproveLastRequest() method writes its results out to console standard output or not.

ShowConsoleStandardOutput is set to true by default when calling SetValidator().

There are three new PowerShell functions (Disable-ShowConsoleStandardOutput, Enable-ShowConsoleStandardOutput, and Get-ShowConsoleStandardOutput) for manipulating the value of the bool from PowerShell.

I also added a new function called Get-IgnoreChainErrors to retrieve the current IgnoreChainErrors value
