### PR TITLE
fix Add-WindowsTrustedCertificate error

### DIFF
--- a/TunableSSLValidator.psm1
+++ b/TunableSSLValidator.psm1
@@ -79,7 +79,7 @@ function Add-WindowsTrustedCertificate {
          }
       }
 
-      $store = new-object System.Security.Cryptography.X509Certificates.X509Store($certStore, $certRootStore)
+      $store = new-object System.Security.Cryptography.X509Certificates.X509Store($certStore, $Root)
       $store.open("MaxAllowed")
       $store.add($Certificate)
       $store.close()


### PR DESCRIPTION
was using wrong certificate store root variable name